### PR TITLE
Update psql.js

### DIFF
--- a/lib/psql.js
+++ b/lib/psql.js
@@ -1,9 +1,7 @@
-const pg = require('pg');
 const Promise = require('bluebird');
 const passport = require('passport');
 
 const connectionString = process.env.PSQL;
-const pgClient = new pg.Client(connectionString);
 const pgp = require('pg-promise')();
 
 const cn = {
@@ -15,7 +13,6 @@ const cn = {
 };
 
 const db = pgp(cn);
-
 
 // export an object with query functions, promisified
 module.exports = {


### PR DESCRIPTION
no point using the low-level `pg` when `pg-promise` is already being used.